### PR TITLE
Refactor LivePreview by removing require-cache

### DIFF
--- a/src/components/LivePlayground.js
+++ b/src/components/LivePlayground.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import LiveEditor from './LiveEditor'
+import LivePreview from './LivePreview'
 
 class LivePlayground extends Component {
   constructor(props) {
@@ -7,11 +8,6 @@ class LivePlayground extends Component {
   }
 
   render() {
-    // LivePreview will be modified by eval.
-    // So, we need to delete cache and re-import it until we find a better solution
-    delete require.cache[require.resolve('./LivePreview')]
-    const LivePreview = require('./LivePreview').default
-
     return (
       <div className="live-playground">
         <LiveEditor code={this.props.code} updateCode={this.props.updateCode} />

--- a/src/components/LivePreview.js
+++ b/src/components/LivePreview.js
@@ -25,12 +25,18 @@ class LivePreview extends Component {
   executeCode(code) {
     // Remove previous result
     ReactDOM.unmountComponentAtNode(this.livePreview)
-    // Make React available for eval
-    const React = require('react') // eslint-disable-line no-unused-vars
 
     try {
       const compiledCode = this.compileCode(code)
-      const result = eval(compiledCode)
+      // Prevent eval to touch global module and exports
+      const execute = (0, eval)(`
+        (function(module, exports, React) {
+          ${compiledCode}
+        })
+      `)
+      const privateModule = { exports: { } }
+      execute(privateModule, privateModule.exports, React)
+      const result = privateModule.exports.default
 
       ReactDOM.render(result, this.livePreview)
     } catch (err) {

--- a/test/components/LivePreview.test.js
+++ b/test/components/LivePreview.test.js
@@ -1,14 +1,10 @@
 import { expect, renderComponent } from '../test-helper'
+import LivePreview from '../../src/components/LivePreview'
 
 describe('LivePreview', () => {
   let component
 
   beforeEach(() => {
-    // LivePreview will be modified by eval.
-    // So, we need to delete cache and re-import it until we find a better solution
-    delete require.cache[require.resolve('../../src/components/LivePreview')]
-    const LivePreview = require('../../src/components/LivePreview').default
-
     const props = {
       code: `var HelloMessage = React.createClass({
               render: function() {


### PR DESCRIPTION
Use indirect function call to limit eval scope to prevent modifying
module and exports
