### PR TITLE
Handle multiple editors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,12 @@
   "plugins": [
     "react"
   ],
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+    },
+  },
   "rules": {
     "arrow-body-style": ["error", "always"],
     "no-trailing-spaces": ["error", { "skipBlankLines": true }],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/codesheepio/codesheep-live-editor#readme",
   "dependencies": {
     "babel-core": "^6.13.2",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
     "codemirror": "^5.17.0",

--- a/src/actions/codeAction.js
+++ b/src/actions/codeAction.js
@@ -1,12 +1,15 @@
-import types from './types'
+import { UPDATE_CODE } from './types'
 
-const updateCode = (code) => {
+const updateCode = (windowId, code) => {
   return {
-    type: types.UPDATE_CODE,
-    code,
+    type: UPDATE_CODE,
+    payload: {
+      windowId,
+      code,
+    }
   }
 }
 
-export default {
-  updateCode
+export {
+  updateCode // eslint-disable-line import/prefer-default-export
 }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,1 +1,1 @@
-export const UPDATE_CODE = 'UPDATE_CODE'
+export const UPDATE_CODE = 'UPDATE_CODE' // eslint-disable-line import/prefer-default-export

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,5 +1,1 @@
-const UPDATE_CODE = 'UPDATE_CODE'
-
-export default {
-  UPDATE_CODE,
-}
+export const UPDATE_CODE = 'UPDATE_CODE'

--- a/src/components/LiveEditor.js
+++ b/src/components/LiveEditor.js
@@ -23,6 +23,7 @@ class LiveEditor extends Component {
       matchBrackets: true,
       theme: 'monokai',
       readOnly: false,
+      lineNumbers: true,
     }
 
     return (

--- a/src/components/LiveEditor.js
+++ b/src/components/LiveEditor.js
@@ -24,6 +24,8 @@ class LiveEditor extends Component {
       theme: 'monokai',
       readOnly: false,
       lineNumbers: true,
+      tabSize: 2,
+      indentUnit: 2,
     }
 
     return (

--- a/src/components/LiveEditor.js
+++ b/src/components/LiveEditor.js
@@ -16,25 +16,13 @@ class LiveEditor extends Component {
   }
 
   render() {
-    const options = {
-      mode: 'jsx',
-      lineWrapping: true,
-      smartIndent: true,
-      matchBrackets: true,
-      theme: 'monokai',
-      readOnly: false,
-      lineNumbers: true,
-      tabSize: 2,
-      indentUnit: 2,
-    }
-
     return (
       <div className="live-editor">
         <CodeMirror
           ref={(ref) => { this.wrapper = ref }}
           className="codemirror"
           external="true"
-          options={options}
+          options={this.props.options}
           value={this.props.code}
           onChange={this.handleCodeChange}
         />
@@ -45,6 +33,7 @@ class LiveEditor extends Component {
 
 LiveEditor.propTypes = {
   editorId: PropTypes.string.isRequired,
+  options: PropTypes.object.isRequired,
   code: PropTypes.string.isRequired,
   updateCode: PropTypes.func.isRequired,
 }

--- a/src/components/LiveEditor.js
+++ b/src/components/LiveEditor.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import CodeMirror from 'react-codemirror'
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/monokai.css'
@@ -12,7 +12,7 @@ class LiveEditor extends Component {
   }
 
   handleCodeChange(code) {
-    this.props.updateCode(code)
+    this.props.updateCode(this.props.editorId, code)
   }
 
   render() {
@@ -44,8 +44,9 @@ class LiveEditor extends Component {
 }
 
 LiveEditor.propTypes = {
-  code: React.PropTypes.string.isRequired,
-  updateCode: React.PropTypes.func.isRequired,
+  editorId: PropTypes.string.isRequired,
+  code: PropTypes.string.isRequired,
+  updateCode: PropTypes.func.isRequired,
 }
 
 LiveEditor.defaultProps = {

--- a/src/components/LivePlayground.js
+++ b/src/components/LivePlayground.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import LiveEditor from './LiveEditor'
 import LivePreview from './LivePreview'
+import { JS_EDITOR } from '../constants/windowIds'
 
 class LivePlayground extends Component {
   constructor(props) {
@@ -10,7 +11,7 @@ class LivePlayground extends Component {
   render() {
     return (
       <div className="live-playground">
-        <LiveEditor code={this.props.code} updateCode={this.props.updateCode} />
+        <LiveEditor editorId={JS_EDITOR} code={this.props.code[JS_EDITOR]} updateCode={this.props.updateCode} />
         <LivePreview code={this.props.code} />
       </div>
     )
@@ -18,12 +19,8 @@ class LivePlayground extends Component {
 }
 
 LivePlayground.propTypes = {
-  code: React.PropTypes.string.isRequired,
+  code: React.PropTypes.object.isRequired,
   updateCode: React.PropTypes.func.isRequired,
-}
-
-LivePlayground.defaultProps = {
-  code: '',
 }
 
 export default LivePlayground

--- a/src/components/LivePlayground.js
+++ b/src/components/LivePlayground.js
@@ -9,9 +9,24 @@ class LivePlayground extends Component {
   }
 
   render() {
+    const commonOptions = {
+      lineWrapping: true,
+      smartIndent: true,
+      matchBrackets: true,
+      theme: 'monokai',
+      readOnly: false,
+      lineNumbers: true,
+      tabSize: 2,
+      indentUnit: 2,
+    }
+
+    const jsOptions = {
+      ...commonOptions,
+      mode: 'jsx',
+    }
     return (
       <div className="live-playground">
-        <LiveEditor editorId={JS_EDITOR} code={this.props.code[JS_EDITOR]} updateCode={this.props.updateCode} />
+        <LiveEditor editorId={JS_EDITOR} options={jsOptions} code={this.props.code[JS_EDITOR]} updateCode={this.props.updateCode} />
         <LivePreview code={this.props.code} />
       </div>
     )

--- a/src/components/LivePreview.js
+++ b/src/components/LivePreview.js
@@ -1,18 +1,19 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import { transform } from 'babel-core'
 import babelPresetEs2015 from 'babel-preset-es2015'
 import babelPresetReact from 'babel-preset-react'
 import babelObjectRestSpread from 'babel-plugin-transform-object-rest-spread'
+import { JS_EDITOR } from '../constants/windowIds'
 
 class LivePreview extends Component {
   componentDidMount() {
-    this.executeCode(this.props.code)
+    this.executeCode(this.props.code[JS_EDITOR])
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.code !== prevProps.code) {
-      this.executeCode(this.props.code)
+    if (this.props.code[JS_EDITOR] !== prevProps.code[JS_EDITOR]) {
+      this.executeCode(this.props.code[JS_EDITOR])
     }
   }
 
@@ -66,7 +67,7 @@ class LivePreview extends Component {
 }
 
 LivePreview.propTypes = {
-  code: React.PropTypes.string.isRequired,
+  code: PropTypes.object.isRequired,
 }
 
 export default LivePreview

--- a/src/components/LivePreview.js
+++ b/src/components/LivePreview.js
@@ -32,16 +32,18 @@ class LivePreview extends Component {
       // Prevent eval to touch global module and exports
       const privateModule = { exports: { } }
 
-      // Construct a function taking 3 params (module, exports, React) and will run compiledCode
-      const execute = new Function(['module', 'exports', 'React'], compiledCode)
+      // Construct a function taking 5 params (module, exports, React, ReactDOM, DOM node to be mounted) and will run compiledCode
+      const execute = new Function(['module', 'exports', 'React', 'ReactDOM', 'mountNode'], compiledCode)
 
-      // Run compiledCode with injected module, exports, and React
-      execute(privateModule, privateModule.exports, React)
+      // Run compiledCode with injected module, exports, and React, ReactDOM, and mounted node
+      // Code in LiveEditor is able to call ReactDOM.render
+      execute(privateModule, privateModule.exports, React, ReactDOM, this.livePreview)
 
       // Code must end with 'export default <ReactClass />' for being rendered with ReactDOM
-      const result = privateModule.exports.default
+      //const result = privateModule.exports.default
+      //ReactDOM.render(result, this.livePreview)
 
-      ReactDOM.render(result, this.livePreview)
+      // In code, use ReactDOM.render(<ReactClass />, mountNode)
     } catch (err) {
       ReactDOM.render(
         <div className="preview-error">{err.toString()}</div>,

--- a/src/components/LivePreview.js
+++ b/src/components/LivePreview.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { transform } from 'babel-core'
 import babelPresetEs2015 from 'babel-preset-es2015'
 import babelPresetReact from 'babel-preset-react'
+import babelObjectRestSpread from 'babel-plugin-transform-object-rest-spread'
 
 class LivePreview extends Component {
   componentDidMount() {
@@ -18,7 +19,10 @@ class LivePreview extends Component {
   compileCode(code) {
     return transform(
       code,
-      { presets: [babelPresetEs2015, babelPresetReact] }
+      {
+        presets: [babelPresetEs2015, babelPresetReact],
+        plugins: [babelObjectRestSpread],
+      }
     ).code
   }
 

--- a/src/constants/windowIds.js
+++ b/src/constants/windowIds.js
@@ -1,0 +1,1 @@
+export const JS_EDITOR = 'JS_EDITOR' // eslint-disable-line import/prefer-default-export

--- a/src/containers/LivePlaygroundContainer.js
+++ b/src/containers/LivePlaygroundContainer.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux'
-import { default as actions } from '../actions/codeAction'
+import { updateCode } from '../actions/codeAction'
 import LivePlayground from '../components/LivePlayground'
 
 const mapStateToProps = (state) => {
   return { code: state.code }
 }
 
-export default connect(mapStateToProps, actions)(LivePlayground)
+export default connect(mapStateToProps, { updateCode })(LivePlayground)

--- a/src/reducers/codeReducer.js
+++ b/src/reducers/codeReducer.js
@@ -1,11 +1,14 @@
-import types from '../actions/types'
+import { UPDATE_CODE } from '../actions/types'
 
-const initialState = ''
+const initialState = {}
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
-    case types.UPDATE_CODE:
-      return action.code
+    case UPDATE_CODE:
+      return {
+        ...state,
+        [action.payload.windowId]: action.payload.code,
+      }
     default:
       return state
   }

--- a/test/actions/codeAction.test.js
+++ b/test/actions/codeAction.test.js
@@ -1,13 +1,16 @@
 import { expect } from '../test-helper'
-import types from '../../src/actions/types'
-import actions from '../../src/actions/codeAction'
+import { UPDATE_CODE } from '../../src/actions/types'
+import { updateCode } from '../../src/actions/codeAction'
 
 describe('Code Action', () => {
   it('should create action with type UPDATE_CODE', () => {
-    const resultAction = actions.updateCode('<TestComponent />')
+    const resultAction = updateCode('JS_EDITOR', '<TestComponent />')
     const expectedAction = {
-      type: types.UPDATE_CODE,
-      code: '<TestComponent />',
+      type: UPDATE_CODE,
+      payload: {
+        windowId: 'JS_EDITOR',
+        code: '<TestComponent />',
+      },
     }
 
     expect(resultAction).to.deep.equal(expectedAction)

--- a/test/components/LiveEditor.test.js
+++ b/test/components/LiveEditor.test.js
@@ -11,11 +11,14 @@ describe('LiveEditor', () => {
 
   beforeEach(() => {
     props = {
+      editorId: 'JS_EDITOR',
       code: '',
       updateCode: sinon.spy(),
     }
     state = {
-      code: '<TestComponent />',
+      code: {
+        JS_EDITOR: '<TestComponent />',
+      },
     }
     component = renderComponent(LiveEditor, props, state)
   })
@@ -45,6 +48,6 @@ describe('LiveEditor', () => {
       }
     )
 
-    expect(props.updateCode).to.have.been.calledWith('Hello')
+    expect(props.updateCode).to.have.been.calledWith('JS_EDITOR', 'Hello')
   })
 })

--- a/test/components/LiveEditor.test.js
+++ b/test/components/LiveEditor.test.js
@@ -14,6 +14,17 @@ describe('LiveEditor', () => {
       editorId: 'JS_EDITOR',
       code: '',
       updateCode: sinon.spy(),
+      options: {
+        mode: 'jsx',
+        lineWrapping: true,
+        smartIndent: true,
+        matchBrackets: true,
+        theme: 'monokai',
+        readOnly: false,
+        lineNumbers: true,
+        tabSize: 2,
+        indentUnit: 2,
+      },
     }
     state = {
       code: {

--- a/test/components/LivePlayground.test.js
+++ b/test/components/LivePlayground.test.js
@@ -6,7 +6,7 @@ describe('LivePlayground', () => {
 
   beforeEach(() => {
     const props = {
-      code: '',
+      code: {},
       updateCode: sinon.stub(),
     }
     component = renderComponent(LivePlayground, props)

--- a/test/components/LivePreview.test.js
+++ b/test/components/LivePreview.test.js
@@ -12,7 +12,7 @@ describe('LivePreview', () => {
               }
             });
 
-            export default <HelloMessage name="CodeSheep" />;`,
+            ReactDOM.render(<HelloMessage name="CodeSheep" />, mountNode);`,
     }
     component = renderComponent(LivePreview, props)
   })

--- a/test/components/LivePreview.test.js
+++ b/test/components/LivePreview.test.js
@@ -3,9 +3,10 @@ import LivePreview from '../../src/components/LivePreview'
 
 describe('LivePreview', () => {
   let component
+  let props
 
   beforeEach(() => {
-    const props = {
+    props = {
       code: `var HelloMessage = React.createClass({
               render: function() {
                 return <div>Hello {this.props.name}</div>;
@@ -22,6 +23,24 @@ describe('LivePreview', () => {
   })
 
   it('should transform and execute code, then, display result', () => {
+    expect(component).to.have.html(
+      '<div data-reactroot=""><!-- react-text: 2 -->Hello <!-- /react-text -->' +
+      '<!-- react-text: 3 -->CodeSheep<!-- /react-text --></div>')
+  })
+
+  it('should handle ES6 class', () => {
+    props = {
+      code: `class Hello extends React.Component {
+              render() {
+                return (
+                  <div>Hello {this.props.name}</div>
+                )
+              }
+            }
+            ReactDOM.render(<Hello name="CodeSheep" />, mountNode)`
+    }
+    component = renderComponent(LivePreview, props)
+
     expect(component).to.have.html(
       '<div data-reactroot=""><!-- react-text: 2 -->Hello <!-- /react-text -->' +
       '<!-- react-text: 3 -->CodeSheep<!-- /react-text --></div>')

--- a/test/components/LivePreview.test.js
+++ b/test/components/LivePreview.test.js
@@ -22,6 +22,17 @@ describe('LivePreview', () => {
     expect(component).to.have.class('live-preview')
   })
 
+  it('should be able to access React and ReactDOM', () => {
+    props = {
+      code: `const ans = React ? <div>YES</div> : <div>NO</div>
+            ReactDOM.render(ans, mountNode)`
+    }
+    component = renderComponent(LivePreview, props)
+
+    expect(component).to.have.html(
+      '<div data-reactroot="">YES</div>')
+  })
+
   it('should transform and execute code, then, display result', () => {
     expect(component).to.have.html(
       '<div data-reactroot=""><!-- react-text: 2 -->Hello <!-- /react-text -->' +

--- a/test/components/LivePreview.test.js
+++ b/test/components/LivePreview.test.js
@@ -7,13 +7,15 @@ describe('LivePreview', () => {
 
   beforeEach(() => {
     props = {
-      code: `var HelloMessage = React.createClass({
+      code: {
+        JS_EDITOR: `var HelloMessage = React.createClass({
               render: function() {
                 return <div>Hello {this.props.name}</div>;
               }
             });
 
             ReactDOM.render(<HelloMessage name="CodeSheep" />, mountNode);`,
+      },
     }
     component = renderComponent(LivePreview, props)
   })
@@ -24,8 +26,10 @@ describe('LivePreview', () => {
 
   it('should be able to access React and ReactDOM', () => {
     props = {
-      code: `const ans = React ? <div>YES</div> : <div>NO</div>
-            ReactDOM.render(ans, mountNode)`
+      code: {
+        JS_EDITOR: `const ans = React ? <div>YES</div> : <div>NO</div>
+                   ReactDOM.render(ans, mountNode)`,
+      },
     }
     component = renderComponent(LivePreview, props)
 
@@ -41,7 +45,8 @@ describe('LivePreview', () => {
 
   it('should handle ES6 class', () => {
     props = {
-      code: `class Hello extends React.Component {
+      code: {
+        JS_EDITOR: `class Hello extends React.Component {
               render() {
                 return (
                   <div>Hello {this.props.name}</div>
@@ -49,6 +54,7 @@ describe('LivePreview', () => {
               }
             }
             ReactDOM.render(<Hello name="CodeSheep" />, mountNode)`
+      },
     }
     component = renderComponent(LivePreview, props)
 

--- a/test/reducers/codeReducer.test.js
+++ b/test/reducers/codeReducer.test.js
@@ -1,46 +1,51 @@
 import { expect } from '../test-helper'
 import codeReducer from '../../src/reducers/codeReducer'
-import types from '../../src/actions/types'
+import { UPDATE_CODE } from '../../src/actions/types'
 
 describe('Code Reducer', () => {
   let curState
 
   beforeEach(() => {
-    curState = 'import React from \'react\'\n' +
-               '\n' +
-               'var HelloMessage = React.createClass({\n' +
-               '  render: function() {\n' +
-               '    return <div>Hello {this.props.name}</div>;\n' +
-               '  }\n' +
-               '});\n' +
-               '   \n' +
-               'export default <HelloMessage name="John" />;'
+    curState = {
+      JS_EDITOR: 'import React from \'react\'\n' +
+                 '\n' +
+                 'var HelloMessage = React.createClass({\n' +
+                 '  render: function() {\n' +
+                 '    return <div>Hello {this.props.name}</div>;\n' +
+                 '  }\n' +
+                 '});\n' +
+                 '   \n' +
+                 'export default <HelloMessage name="John" />;',
+    }
   })
 
   it('should return correct initial state', () => {
     const resultState = codeReducer(undefined, {})
-    const expectedState = ''
+    const expectedState = {}
 
-    expect(resultState).to.equal(expectedState)
+    expect(resultState).to.deep.equal(expectedState)
   })
 
   it('should update state with new code', () => {
-    const newCode = 'import React from \'react\'\n' +
-                    '\n' +
-                    'var TestComponent = React.createClass({\n' +
+    const newCode = 'var TestComponent = React.createClass({\n' +
                     '  render: function() {\n' +
                     '    return <div>Test {this.props.name}</div>;\n' +
                     '  }\n' +
                     '});\n' +
                     '   \n' +
-                    'export default <TestComponent name="Alice" />;'
+                    'ReactDOM.render(<TestComponent name="Alice" />, mountNode);'
     const action = {
-      type: types.UPDATE_CODE,
-      code: newCode,
+      type: UPDATE_CODE,
+      payload: {
+        windowId: 'JS_EDITOR',
+        code: newCode,
+      }
     }
     const resultState = codeReducer(curState, action)
-    const expectedState = newCode
+    const expectedState = {
+      JS_EDITOR: newCode,
+    }
 
-    expect(resultState).to.equal(expectedState)
+    expect(resultState).to.deep.equal(expectedState)
   })
 })


### PR DESCRIPTION
Close #11 
- Refactor code state tree to be key-value pairs which key is editorId, value is code for that editor.
- Editor option including language syntax highlight is passed via props to LiveEditor
